### PR TITLE
Fix show all, birthday age accuracy, and details layout

### DIFF
--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -168,6 +168,10 @@ export default function MainContent() {
 
   // === Render ===
 
+  console.log("Display count:", displayCount);
+  console.log("Upcoming birthdays (pre-pinned sort):", upcoming);
+  console.log("Combined list (after pinned sort):", combinedList);  
+
   return (
     <main className="flex flex-1 overflow-hidden">
       {/* Left Column: List View */}
@@ -262,10 +266,7 @@ export default function MainContent() {
               <h3 className="text-md font-bold text-teal-800 mb-2">{month}</h3>
               <ul key={displayCount} className="space-y-4">
                 {peopleInMonth.map((person) => {
-                  const age = person.birthdayThisYear.diff(
-                    dayjs(person.birthday),
-                    "year"
-                  );
+                  const age = dayjs().diff(dayjs(person.birthday), "year");
                   const daysUntil = person.birthdayThisYear.diff(today, "day");
                   const daysLabel = person.birthdayThisYear.isToday()
                     ? "Today"
@@ -347,7 +348,7 @@ export default function MainContent() {
       </section>
 
       {/* Right Column: Person Details */}
-      <section className="w-1/2 p-4 overflow-y-auto bg-lavender">
+      <section className="w-1/2 max-h-[calc(100vh-200px)] overflow-y-auto p-4 bg-lavender">
         {selectedPerson ? (
           <PersonDetails
             person={selectedPerson}
@@ -360,7 +361,7 @@ export default function MainContent() {
             onDelete={handleDelete}
           />
         ) : (
-          <div className="flex flex-col items-center justify-center h-full text-center text-gray-500">
+          <div className="flex flex-col items-center justify-start min-h-full pt-10">
             <Image
               src="/empty-state.png"
               alt="No birthday selected"

--- a/src/app/components/PersonDetails.tsx
+++ b/src/app/components/PersonDetails.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import { PersonWithBirthday } from "@/types";
+import dayjs from "dayjs";
+
 
 // Define the expected props for the component
 type Props = {
@@ -56,11 +58,32 @@ export default function PersonDetails({
       {/* Person details: birthday, phone, email, etc. */}
       <div className="text-gray-700 space-y-2 text-center">
         {/* Display fields/p tags if exist */}
-        {person.birthday && (
-          <p>
-            <strong>Birthday:</strong> {person.birthday}
-          </p>
-        )}
+        {person.birthday && (() => {
+          const birthday = dayjs(person.birthday);
+          const today = dayjs();
+
+          let birthdayThisYear = birthday.year(today.year());
+          if (birthdayThisYear.isBefore(today, "day")) {
+            birthdayThisYear = birthdayThisYear.add(1, "year");
+          }
+
+          const currentAge = today.diff(birthday, "year");
+          const age = currentAge + 1;
+          const daysUntil = birthdayThisYear.diff(today, "day");
+          const formattedBirthday = birthday.format("MM/DD/YYYY");
+
+          return (
+            <>
+              <p className="font-semibold text-black">
+                {person.name} is turning {age} in {daysUntil === 0 ? "today!" : `${daysUntil} day${daysUntil !== 1 ? "s" : ""}`}.
+              </p>
+              <p>
+                <strong>Birthday:</strong> {formattedBirthday}
+              </p>
+            </>
+          );
+        })()}
+
         {person.phone && (
           <p>
             <strong>Phone:</strong> {person.phone}

--- a/src/lib/sorting/sortByUpcoming.ts
+++ b/src/lib/sorting/sortByUpcoming.ts
@@ -10,7 +10,7 @@ export function sortByUpcoming({
   people,
   today,
   activeCategory = null,
-  displayCount = 4,
+  displayCount,
 }: {
   people: Person[];
   today: dayjs.Dayjs;
@@ -46,5 +46,7 @@ export function sortByUpcoming({
   );
 
   // Return only the top N
-  return sorted.slice(0, displayCount);
+  return typeof displayCount === "number"
+    ? sorted.slice(0, displayCount)
+    : sorted;
 }


### PR DESCRIPTION
- Fixed the “Show All” option. It now correctly displays all entries.
- Adjusted the height of the birthday details column to no longer stretch to match the overflowing birthday list.
- Updated birthday card “Age” labels to show the person’s current age, not the age they’re turning.
- In the birthday details view, added a line showing:  
  `"Name is turning X in Y days"` above the birthday.
- Changed birthday format in the details section from `YYYY-MM-DD` to `MM/DD/YYYY`.

- I didn’t introduce any new performance or accessibility issues.
- Existing performance issues found in Lighthouse diagnostics still need to be addressed 