### PR TITLE
Fix birthday logic for age and message formatting

### DIFF
--- a/src/app/components/MainContent.tsx
+++ b/src/app/components/MainContent.tsx
@@ -225,7 +225,10 @@ export default function MainContent() {
                 {peopleInMonth.map((person) => {
                   const age = dayjs().diff(dayjs(person.birthday), "year");
                   const daysUntil = person.birthdayThisYear.diff(today, "day");
-                  const daysLabel = person.birthdayThisYear.isToday() ? "Today" : `${daysUntil} days`;
+                  const adjustedDaysUntil = person.birthdayThisYear.isToday() ? 0 : daysUntil + 1;
+                  const daysLabel = adjustedDaysUntil === 0
+                    ? "Today"
+                    : `${adjustedDaysUntil} day${adjustedDaysUntil !== 1 ? "s" : ""}`;
 
                   return (
                     <li

--- a/src/app/components/PersonDetails.tsx
+++ b/src/app/components/PersonDetails.tsx
@@ -104,23 +104,27 @@ export default function PersonDetails({
 
         {person.birthday && (() => {
           const birthday = dayjs(person.birthday);
-          const today = dayjs();
+          const today = dayjs().startOf("day");
 
-          let birthdayThisYear = birthday.year(today.year());
-          if (birthdayThisYear.isBefore(today, "day")) {
+          let birthdayThisYear = birthday.set("year", today.year()).startOf("day");
+          if (birthdayThisYear.isBefore(today)) {
             birthdayThisYear = birthdayThisYear.add(1, "year");
           }
 
           const currentAge = today.diff(birthday, "year");
-          const age = currentAge + 1;
           const daysUntil = birthdayThisYear.diff(today, "day");
+          const displayAge = daysUntil > 0 ? currentAge + 1 : currentAge;
           const formattedBirthday = birthday.format("MM/DD/YYYY");
 
           return (
             <>
               <p className="font-semibold text-black">
 
-                {person.name} is turning {age} in {daysUntil === 0 ? "today!" : `${daysUntil} day${daysUntil !== 1 ? "s" : ""}`}.
+                {daysUntil === 0
+                  ? `${person.name} is turning ${displayAge} today!`
+                  : daysUntil === 1
+                    ? `${person.name} is turning ${displayAge} tomorrow.`
+                    : `${person.name} is turning ${displayAge} in ${daysUntil} days.`}
 
               </p>
               <p>


### PR DESCRIPTION
Changes made:
- Updated the logic for determining `daysUntil` and `age` using start-of-day comparison
- Ensured that the correct age is shown only on or after the actual birthday
- Improved message formatting to show:
  - "Name is turning X today!"
  - "Name is turning X tomorrow."
  - "Name is turning X in X days."

Tested on 8/07/2024 with 3 birthday entries.
- Birthday 1 (08/07/2020) → displays "turning 5 today!"
- Birthday 2 (08/08/2020) → displays "turning 5 tomorrow."
- Birthday 3 (08/09/2020) → displays "turning 5 in 2 days."